### PR TITLE
fix typo

### DIFF
--- a/src/isanlp/en/processor_tokenizer_nltk_en.py
+++ b/src/isanlp/en/processor_tokenizer_nltk_en.py
@@ -37,5 +37,4 @@ class ProcessorTokenizerNltkEn:
             List of Token objects.
         """
         
-        return [Token(text[start : end], start, end) for (start, end) in self._nltk_proc.span_tokenize(text)]
-    
+        return [Token(text[start : end], start, end) for (start, end) in self._proc.span_tokenize(text)]


### PR DESCRIPTION
Instance of 'ProcessorTokenizerNltkEn' has no '_nltk_proc' member